### PR TITLE
feat: add interactive terminal + animated Claude creature

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import NowPlaying from './components/ui/NowPlaying';
 const Hero = lazy(() => import("./components/sections/Hero"));
 const Skills = lazy(() => import("./components/sections/Skills"));
 const Projects = lazy(() => import("./components/sections/Projects"));
+const Terminal = lazy(() => import("./components/sections/Terminal"));
 const Footer = lazy(() => import("./components/layout/Footer"));
 const TopNav = lazy(() => import("./components/layout/TopNav"));
 const Music = lazy(() => import("./components/sections/Music"));
@@ -77,6 +78,16 @@ function App() {
                 <Suspense fallback={<LoadingLine />}>
                   <ErrorBoundary>
                     <Projects {...projectsProps} />
+                  </ErrorBoundary>
+                </Suspense>
+              }
+            />
+            <Route
+              path="/terminal"
+              element={
+                <Suspense fallback={<LoadingLine />}>
+                  <ErrorBoundary>
+                    <Terminal />
                   </ErrorBoundary>
                 </Suspense>
               }

--- a/src/components/layout/TopNav.js
+++ b/src/components/layout/TopNav.js
@@ -17,7 +17,9 @@ const navLinkStyle = (isActive) => ({
 
 const TopNav = () => {
   const location = useLocation();
-  const cwd = location.pathname === '/' ? '~' : '~/projects';
+  const cwd =
+    location.pathname === '/terminal' ? '~/terminal' :
+    location.pathname === '/projects'  ? '~/projects'  : '~';
 
   return (
     <nav
@@ -49,6 +51,9 @@ const TopNav = () => {
         </NavLink>
         <NavLink to="/projects" style={({ isActive }) => navLinkStyle(isActive)}>
           projects
+        </NavLink>
+        <NavLink to="/terminal" style={({ isActive }) => navLinkStyle(isActive)}>
+          terminal
         </NavLink>
       </div>
     </nav>

--- a/src/components/sections/Terminal.js
+++ b/src/components/sections/Terminal.js
@@ -1,0 +1,74 @@
+import React, { useRef, useCallback } from 'react';
+import useTerminal from '../../hooks/useTerminal';
+import TerminalBoot from '../terminal/TerminalBoot';
+import TerminalOutput from '../terminal/TerminalOutput';
+import TerminalInput from '../terminal/TerminalInput';
+import CreatureMascot from '../terminal/CreatureMascot';
+
+export default function Terminal() {
+  const {
+    lines,
+    inputValue,
+    setInputValue,
+    creatureState,
+    isBooting,
+    handleKeyDown,
+    handleBootComplete,
+  } = useTerminal();
+
+  const containerRef = useRef(null);
+
+  const focusInput = useCallback(() => {
+    const input = containerRef.current?.querySelector('input');
+    input?.focus();
+  }, []);
+
+  return (
+    <section
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: 'calc(100vh - 160px)',
+        marginBottom: '1rem',
+      }}
+    >
+      {/* Decorative title bar */}
+      <div className="terminal-titlebar">
+        <span className="terminal-dot terminal-dot--red" />
+        <span className="terminal-dot terminal-dot--yellow" />
+        <span className="terminal-dot terminal-dot--green" />
+        <span className="terminal-titlebar-label">
+          rohith@portfolio — terminal
+        </span>
+      </div>
+
+      {/* Main terminal body */}
+      <div
+        className="terminal-body"
+        ref={containerRef}
+        onClick={focusInput}
+      >
+        {/* Scrollable output area */}
+        <div className="terminal-scroll-area">
+          {isBooting && <TerminalBoot onComplete={handleBootComplete} />}
+          <TerminalOutput lines={lines} />
+
+          {/* Creature lives here, floating in bottom-right */}
+          <CreatureMascot animationState={creatureState} />
+        </div>
+
+        {/* Sticky input line */}
+        {!isBooting && (
+          <div className="terminal-input-wrapper">
+            <TerminalInput
+              value={inputValue}
+              onChange={setInputValue}
+              onKeyDown={handleKeyDown}
+              disabled={isBooting}
+            />
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/terminal/CreatureMascot.js
+++ b/src/components/terminal/CreatureMascot.js
@@ -1,0 +1,127 @@
+import React, { useRef, useEffect } from 'react';
+import gsap from 'gsap';
+
+const STATE_BODY_CLASS = {
+  celebrate: 'creature-body creature-body--happy',
+  error:     'creature-body creature-body--sad',
+  wave:      'creature-body creature-body--happy',
+  spin:      'creature-body',
+  thinking:  'creature-body creature-body--thinking',
+  idle:      'creature-body',
+  boot:      'creature-body',
+};
+
+export default function CreatureMascot({ animationState }) {
+  const wrapperRef = useRef(null);
+  const bodyRef    = useRef(null);
+  const armRRef    = useRef(null);
+  const bubbleRef  = useRef(null);
+
+  // Pop in on mount
+  useEffect(() => {
+    if (!wrapperRef.current) return;
+    gsap.fromTo(
+      wrapperRef.current,
+      { scale: 0.1, opacity: 0 },
+      { scale: 1, opacity: 1, duration: 0.7, ease: 'elastic.out(1.2, 0.5)', delay: 0.2 }
+    );
+  }, []);
+
+  useEffect(() => {
+    if (!bodyRef.current || !wrapperRef.current) return;
+
+    gsap.killTweensOf([bodyRef.current, armRRef.current, wrapperRef.current]);
+
+    // Update body class
+    bodyRef.current.className = STATE_BODY_CLASS[animationState] || 'creature-body';
+
+    switch (animationState) {
+      case 'celebrate':
+        gsap.timeline()
+          .to(bodyRef.current, { y: -22, duration: 0.18, ease: 'power2.out' })
+          .to(bodyRef.current, { y: 0,   duration: 0.28, ease: 'bounce.out' })
+          .to(bodyRef.current, { y: -12, duration: 0.14, ease: 'power2.out' })
+          .to(bodyRef.current, { y: 0,   duration: 0.22, ease: 'bounce.out' });
+        break;
+
+      case 'error':
+        gsap.to(bodyRef.current, {
+          keyframes: [
+            { x: -7 }, { x: 7 }, { x: -5 }, { x: 5 }, { x: 0 },
+          ],
+          duration: 0.08,
+          ease: 'none',
+          repeat: 0,
+        });
+        break;
+
+      case 'spin':
+        gsap.to(wrapperRef.current, {
+          rotation: 360,
+          duration: 0.75,
+          ease: 'power1.inOut',
+          onComplete: () => { wrapperRef.current && (wrapperRef.current.style.transform = ''); },
+        });
+        break;
+
+      case 'wave':
+        if (armRRef.current) {
+          gsap.timeline()
+            .to(armRRef.current, { rotation: -45, transformOrigin: 'bottom center', duration: 0.12 })
+            .to(armRRef.current, { rotation: 20,  duration: 0.12 })
+            .to(armRRef.current, { rotation: -45, duration: 0.12 })
+            .to(armRRef.current, { rotation: 20,  duration: 0.12 })
+            .to(armRRef.current, { rotation: 0,   duration: 0.2, ease: 'elastic.out(1, 0.5)' });
+        }
+        break;
+
+      default:
+        gsap.set(bodyRef.current, { y: 0, x: 0 });
+        if (armRRef.current) gsap.set(armRRef.current, { rotation: 0 });
+        break;
+    }
+  }, [animationState]);
+
+  const isThinking = animationState === 'thinking';
+
+  return (
+    <div className="creature-wrapper" ref={wrapperRef} aria-hidden="true">
+      {isThinking && (
+        <div className="creature-bubble" ref={bubbleRef}>...</div>
+      )}
+
+      {/* Arms (behind body visually) */}
+      <div style={{ position: 'relative' }}>
+        <div className="creature-arm-left" />
+        <div className="creature-arm-right" ref={armRRef} />
+
+        {/* Body */}
+        <div className="creature-body" ref={bodyRef}>
+          {/* Highlight sheen */}
+          <div className="creature-highlight" />
+
+          {/* Eyes */}
+          <div className="creature-eyes">
+            <div className="creature-eye creature-eye-left">
+              <div className="creature-pupil" />
+              <div className="creature-shine" />
+            </div>
+            <div className="creature-eye creature-eye-right">
+              <div className="creature-pupil" />
+              <div className="creature-shine" />
+            </div>
+          </div>
+
+          {/* Mouth */}
+          <div className={`creature-mouth${animationState === 'error' ? ' creature-mouth--sad' : ''}`} />
+        </div>
+      </div>
+
+      {/* Feet */}
+      <div className="creature-feet">
+        <div className="creature-foot" />
+        <div className="creature-foot" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/terminal/TerminalBoot.js
+++ b/src/components/terminal/TerminalBoot.js
@@ -1,0 +1,38 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { BOOT_TEXT } from '../../constants/terminalCommands';
+
+export default function TerminalBoot({ onComplete }) {
+  const [displayed, setDisplayed] = useState('');
+  const hasStarted = useRef(false);
+
+  useEffect(() => {
+    if (hasStarted.current) return;
+    hasStarted.current = true;
+
+    let i = 0;
+    const interval = setInterval(() => {
+      i++;
+      setDisplayed(BOOT_TEXT.slice(0, i));
+      if (i >= BOOT_TEXT.length) {
+        clearInterval(interval);
+        setTimeout(onComplete, 300);
+      }
+    }, 12);
+
+    return () => clearInterval(interval);
+  }, [onComplete]);
+
+  return (
+    <pre style={{
+      color: 'var(--term-green)',
+      fontFamily: 'inherit',
+      fontSize: 'inherit',
+      margin: '0 0 8px 0',
+      whiteSpace: 'pre-wrap',
+      lineHeight: 1.5,
+    }}>
+      {displayed}
+      <span className="term-cursor" />
+    </pre>
+  );
+}

--- a/src/components/terminal/TerminalInput.js
+++ b/src/components/terminal/TerminalInput.js
@@ -1,0 +1,55 @@
+import React, { useRef, useEffect } from 'react';
+
+export default function TerminalInput({ value, onChange, onKeyDown, disabled }) {
+  const inputRef = useRef(null);
+
+  // Focus when enabled (after boot)
+  useEffect(() => {
+    if (!disabled) {
+      // Slight delay prevents iOS keyboard pop-up on load
+      const t = setTimeout(() => inputRef.current?.focus(), 100);
+      return () => clearTimeout(t);
+    }
+  }, [disabled]);
+
+  return (
+    <div
+      className="terminal-input-line"
+      onClick={() => inputRef.current?.focus()}
+    >
+      <span style={{ color: 'var(--term-purple)', fontWeight: 600 }}>rohith</span>
+      <span style={{ color: '#444' }}>@</span>
+      <span style={{ color: 'var(--term-green)', fontWeight: 600 }}>portfolio</span>
+      <span style={{ color: '#444' }}>:</span>
+      <span style={{ color: 'var(--term-purple)' }}>~</span>
+      <span style={{ color: '#e4e4e4' }}>$ </span>
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        disabled={disabled}
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="none"
+        spellCheck={false}
+        inputMode="text"
+        aria-label="terminal input"
+        style={{
+          background: 'transparent',
+          border: 'none',
+          outline: 'none',
+          color: 'var(--term-cyan)',
+          fontFamily: 'inherit',
+          fontSize: 'inherit',
+          caretColor: 'var(--term-green)',
+          flex: 1,
+          minWidth: 0,
+          width: '100%',
+        }}
+      />
+      {!value && !disabled && <span className="term-cursor" />}
+    </div>
+  );
+}

--- a/src/components/terminal/TerminalOutput.js
+++ b/src/components/terminal/TerminalOutput.js
@@ -1,0 +1,40 @@
+import React, { useEffect, useRef } from 'react';
+
+const PROMPT = (
+  <span>
+    <span style={{ color: 'var(--term-purple)', fontWeight: 600 }}>rohith</span>
+    <span style={{ color: '#444' }}>@</span>
+    <span style={{ color: 'var(--term-green)', fontWeight: 600 }}>portfolio</span>
+    <span style={{ color: '#444' }}>:</span>
+    <span style={{ color: 'var(--term-purple)' }}>~</span>
+    <span style={{ color: '#e4e4e4' }}>$ </span>
+  </span>
+);
+
+export default function TerminalOutput({ lines }) {
+  const bottomRef = useRef(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [lines]);
+
+  return (
+    <div className="terminal-output">
+      {lines.map(line => (
+        <div key={line.id} style={{ lineHeight: 1.6, minHeight: '1.2em' }}>
+          {line.isCommand ? (
+            <span>
+              {PROMPT}
+              <span style={{ color: line.color || 'var(--term-cyan)' }}>{line.text}</span>
+            </span>
+          ) : (
+            <span style={{ color: line.color || 'var(--term-text)' }}>
+              {line.text}
+            </span>
+          )}
+        </div>
+      ))}
+      <div ref={bottomRef} style={{ height: 1 }} />
+    </div>
+  );
+}

--- a/src/constants/terminalCommands.js
+++ b/src/constants/terminalCommands.js
@@ -1,0 +1,341 @@
+export const BOOT_TEXT = `
+  ____       _     _ _   _
+ |  _ \\ ___ | |__ (_) |_| |__
+ | |_) / _ \\| '_ \\| | __| '_ \\
+ |  _ < (_) | | | | | |_| | | |
+ |_| \\_\\___/|_| |_|_|\\__|_| |_|
+
+ rohith illuri — self-taught developer
+ portfolio v2.0.0 — type 'help' to get started
+ ─────────────────────────────────────────────
+`.trimStart();
+
+const SKILLS_LIST = [
+  'JavaScript', 'TypeScript', 'Python', 'Rust',
+  'React', 'Node.js', 'GraphQL', 'Docker',
+  'PostgreSQL', 'Redis', 'AWS', 'Git',
+  'HTML', 'CSS', 'Tailwind', 'Linux',
+];
+
+const FAKE_GIT_LOG = [
+  { hash: 'a3f7b2e', date: '2024-12-01', msg: 'feat: add GSAP animations to hero section' },
+  { hash: '9c1d8f4', date: '2024-11-20', msg: 'fix: mobile nav overflow on small screens' },
+  { hash: '4e2a71b', date: '2024-11-15', msg: 'feat: add YouTube background music player' },
+  { hash: '8b3c9d1', date: '2024-11-10', msg: 'refactor: extract hooks into separate files' },
+  { hash: '1f0e5c7', date: '2024-10-28', msg: 'feat: deploy Crave food marketplace to Vercel' },
+  { hash: '6a4d2b8', date: '2024-10-15', msg: 'feat: cryptoapp live market data integration' },
+  { hash: '2c8f3e9', date: '2024-09-30', msg: 'docs: add project READMEs and screenshots' },
+  { hash: '7d1b0a5', date: '2024-09-12', msg: 'init: scaffold portfolio with React + Tailwind' },
+];
+
+const FAKE_FS = {
+  'about.txt': [
+    { text: 'Name:     Rohith Illuri', color: 'var(--term-text)' },
+    { text: 'Role:     Self-Taught Developer', color: 'var(--term-text)' },
+    { text: 'Based:    Earth (usually online)', color: 'var(--term-text)' },
+    { text: '', color: '' },
+    { text: 'I build things with React, Node, and whatever else gets the', color: 'var(--term-dim)' },
+    { text: 'job done. Currently obsessed with performance and clean UIs.', color: 'var(--term-dim)' },
+    { text: '', color: '' },
+    { text: 'When not coding:', color: 'var(--term-text)' },
+    { text: '  → Deadlifting heavy things', color: 'var(--term-cyan)' },
+    { text: '  → Listening to AC/DC at unreasonable volumes', color: 'var(--term-cyan)' },
+    { text: '  → Watching Kill Bill for the 12th time', color: 'var(--term-cyan)' },
+  ],
+  'readme.txt': [
+    { text: '╔══════════════════════════════════════════════════╗', color: 'var(--term-border-color, #2a2a2a)' },
+    { text: '║           ROHITH ILLURI — PORTFOLIO              ║', color: 'var(--term-purple)' },
+    { text: '╚══════════════════════════════════════════════════╝', color: 'var(--term-border-color, #2a2a2a)' },
+    { text: '', color: '' },
+    { text: 'A developer who ships things.', color: 'var(--term-text)' },
+    { text: '', color: '' },
+    { text: 'PROJECTS', color: 'var(--term-yellow)' },
+    { text: '  Crave        — food marketplace built with React + Node', color: 'var(--term-text)' },
+    { text: '  CryptoApp    — live crypto market data dashboard', color: 'var(--term-text)' },
+    { text: '  Toronto Proj — community project (details inside)', color: 'var(--term-text)' },
+    { text: '  Nnets        — neural network experiments', color: 'var(--term-text)' },
+    { text: '', color: '' },
+    { text: 'LINKS', color: 'var(--term-yellow)' },
+    { text: '  github.com/rohithIlluri', color: 'var(--term-cyan)' },
+    { text: '', color: '' },
+    { text: 'LICENSE: MIT — use it, remix it, ship it.', color: 'var(--term-dim)' },
+  ],
+  'stats.json': [
+    { text: '{', color: 'var(--term-text)' },
+    { text: '  "deadlift_kg":      180,', color: 'var(--term-green)' },
+    { text: '  "bench_kg":         120,', color: 'var(--term-green)' },
+    { text: '  "5k_run_min":       24,', color: 'var(--term-green)' },
+    { text: '  "typing_wpm":       110,', color: 'var(--term-green)' },
+    { text: '  "commits_total":    "a lot",', color: 'var(--term-yellow)' },
+    { text: '  "coffee_per_day":   3,', color: 'var(--term-yellow)' },
+    { text: '  "bugs_introduced":  "classified"', color: 'var(--term-red)' },
+    { text: '}', color: 'var(--term-text)' },
+  ],
+  'music.txt': [
+    { text: '01  AC/DC           — Highway to Hell, Back in Black', color: 'var(--term-text)' },
+    { text: '02  The Beatles     — Come Together, Let It Be', color: 'var(--term-text)' },
+    { text: '03  Led Zeppelin    — Stairway to Heaven, Kashmir', color: 'var(--term-text)' },
+    { text: '04  Pink Floyd      — Comfortably Numb, Wish You Were Here', color: 'var(--term-text)' },
+  ],
+  'movies.txt': [
+    { text: '01  Kill Bill Vol. 1   (2003) — Quentin Tarantino', color: 'var(--term-text)' },
+    { text: '02  The Dark Knight    (2008) — Christopher Nolan', color: 'var(--term-text)' },
+    { text: '03  Interstellar        (2014) — Christopher Nolan', color: 'var(--term-text)' },
+    { text: '04  Pulp Fiction        (1994) — Quentin Tarantino', color: 'var(--term-text)' },
+  ],
+};
+
+const MATRIX_FRAMES = [
+  '01001000 01100101 01101100 01101100 01101111',
+  '11001010 00110101 10100011 01010110 11100010',
+  '00101010 11011001 01110100 10001101 00111011',
+  '10110100 01001101 11010010 00101011 10011100',
+  '01110001 10100010 00011011 11001001 01010111',
+];
+
+// ──────────────────────────────────────────────
+// Command runner
+// ──────────────────────────────────────────────
+
+function ok(lines, hint = 'celebrate') {
+  return { lines, creatureHint: hint };
+}
+
+function err(text) {
+  return {
+    lines: [{ text, color: 'var(--term-red)' }],
+    creatureHint: 'error',
+  };
+}
+
+export function runCommand(raw, context = {}) {
+  const trimmed = raw.trim();
+  if (!trimmed) return { lines: [], creatureHint: 'idle' };
+
+  const parts = trimmed.split(/\s+/);
+  const cmd = parts[0].toLowerCase();
+  const args = parts.slice(1).join(' ');
+
+  switch (cmd) {
+    case 'help':
+      return ok([
+        { text: 'Available commands:', color: 'var(--term-yellow)' },
+        { text: '', color: '' },
+        { text: '  about          about me', color: 'var(--term-text)' },
+        { text: '  whoami         who is this?', color: 'var(--term-text)' },
+        { text: '  skills         tech stack', color: 'var(--term-text)' },
+        { text: '  projects       project list', color: 'var(--term-text)' },
+        { text: '  ls             list files', color: 'var(--term-text)' },
+        { text: '  cat <file>     read a file', color: 'var(--term-text)' },
+        { text: '  git log        fake commit history', color: 'var(--term-text)' },
+        { text: '  git status     repo status', color: 'var(--term-text)' },
+        { text: '  history        command history', color: 'var(--term-text)' },
+        { text: '  date           current date', color: 'var(--term-text)' },
+        { text: '  uname -a       system info', color: 'var(--term-text)' },
+        { text: '  echo <text>    echo text', color: 'var(--term-text)' },
+        { text: '  pwd            print working dir', color: 'var(--term-text)' },
+        { text: '  man rohith     manual page', color: 'var(--term-text)' },
+        { text: '  ping <host>    ping something', color: 'var(--term-text)' },
+        { text: '  wave           make the creature wave', color: 'var(--term-text)' },
+        { text: '  spin           make the creature spin', color: 'var(--term-text)' },
+        { text: '  dance          creature dance party', color: 'var(--term-text)' },
+        { text: '  clear          clear the terminal', color: 'var(--term-text)' },
+        { text: '', color: '' },
+        { text: '  (psst: try `matrix` for a secret)', color: 'var(--term-dim)' },
+      ]);
+
+    case 'about':
+      return ok(FAKE_FS['about.txt']);
+
+    case 'whoami':
+      return ok([
+        { text: 'rohith illuri', color: 'var(--term-green)' },
+        { text: 'self-taught developer · builder · lifter', color: 'var(--term-dim)' },
+      ]);
+
+    case 'skills':
+      return ok([
+        { text: 'Tech stack:', color: 'var(--term-yellow)' },
+        { text: '', color: '' },
+        ...SKILLS_LIST.map(s => ({ text: `  ▸ ${s}`, color: 'var(--term-cyan)' })),
+      ]);
+
+    case 'projects':
+      return ok([
+        { text: 'Projects:', color: 'var(--term-yellow)' },
+        { text: '', color: '' },
+        { text: '  Crave         food marketplace — React + Node + PostgreSQL', color: 'var(--term-text)' },
+        { text: '  CryptoApp     live market dashboard — React + WebSocket API', color: 'var(--term-text)' },
+        { text: '  Toronto Proj  community platform — full-stack', color: 'var(--term-text)' },
+        { text: '  Nnets         neural network experiments — Python', color: 'var(--term-text)' },
+        { text: '', color: '' },
+        { text: '  → github.com/rohithIlluri', color: 'var(--term-cyan)' },
+      ]);
+
+    case 'ls': {
+      const target = args.trim();
+      if (!target || target === '.') {
+        return ok([
+          { text: 'about.txt   readme.txt   stats.json   music.txt   movies.txt', color: 'var(--term-text)' },
+          { text: 'skills/     projects/', color: 'var(--term-cyan)' },
+        ]);
+      }
+      if (target === 'skills/' || target === 'skills') {
+        return ok(SKILLS_LIST.map(s => ({ text: s, color: 'var(--term-cyan)' })));
+      }
+      if (target === 'projects/' || target === 'projects') {
+        return ok([
+          { text: 'Crave/   CryptoApp/   toronto-project/   Nnets/', color: 'var(--term-cyan)' },
+        ]);
+      }
+      return err(`ls: cannot access '${target}': No such file or directory`);
+    }
+
+    case 'cat': {
+      const file = args.trim();
+      if (!file) return err('cat: missing file operand');
+      if (FAKE_FS[file]) return ok(FAKE_FS[file]);
+      return err(`cat: ${file}: No such file or directory`);
+    }
+
+    case 'git': {
+      const sub = parts[1];
+      const flag = parts[2];
+      if (sub === 'log' && flag === '--oneline') {
+        return ok(FAKE_GIT_LOG.map(c => ({
+          text: `${c.hash}  ${c.msg}`,
+          color: 'var(--term-text)',
+        })));
+      }
+      if (sub === 'log') {
+        return ok(
+          FAKE_GIT_LOG.flatMap(c => [
+            { text: `commit ${c.hash}da3f9b2c1e5a7d4f8b0c3e6a9d2f5b8c1e4a7d0f`, color: 'var(--term-yellow)' },
+            { text: `Date:   ${c.date}`, color: 'var(--term-dim)' },
+            { text: `    ${c.msg}`, color: 'var(--term-text)' },
+            { text: '', color: '' },
+          ])
+        );
+      }
+      if (sub === 'status') {
+        return ok([
+          { text: 'On branch main', color: 'var(--term-text)' },
+          { text: "Your branch is up to date with 'origin/main'.", color: 'var(--term-text)' },
+          { text: '', color: '' },
+          { text: 'nothing to commit, working tree clean', color: 'var(--term-green)' },
+        ]);
+      }
+      return err(`git: '${sub}' is not a git command. Try 'git log' or 'git status'.`);
+    }
+
+    case 'history': {
+      const hist = context.history || [];
+      if (!hist.length) return ok([{ text: '(no commands yet)', color: 'var(--term-dim)' }]);
+      return ok(hist.map((h, i) => ({ text: `  ${String(i + 1).padStart(3)}  ${h}`, color: 'var(--term-dim)' })));
+    }
+
+    case 'date':
+      return ok([{ text: new Date().toString(), color: 'var(--term-text)' }]);
+
+    case 'pwd':
+      return ok([{ text: '/home/rohith', color: 'var(--term-text)' }]);
+
+    case 'uname':
+      return ok([
+        { text: 'Linux portfolio 6.1.0 #1 SMP x86_64 GNU/Linux', color: 'var(--term-text)' },
+        { text: 'user: rohith@portfolio', color: 'var(--term-dim)' },
+      ]);
+
+    case 'echo':
+      return ok(
+        [{ text: args || '', color: 'var(--term-green)' }],
+        'wave'
+      );
+
+    case 'man':
+      if (args.trim() === 'rohith') {
+        return ok([
+          { text: 'ROHITH(1)              User Commands              ROHITH(1)', color: 'var(--term-dim)' },
+          { text: '', color: '' },
+          { text: 'NAME', color: 'var(--term-yellow)' },
+          { text: '       rohith - a developer who ships things', color: 'var(--term-text)' },
+          { text: '', color: '' },
+          { text: 'SYNOPSIS', color: 'var(--term-yellow)' },
+          { text: '       rohith [--coffee n] [--music rock] [--lift heavy]', color: 'var(--term-text)' },
+          { text: '', color: '' },
+          { text: 'DESCRIPTION', color: 'var(--term-yellow)' },
+          { text: '       Self-taught developer. Builds UIs. Writes clean code.', color: 'var(--term-text)' },
+          { text: '       Occasionally breaks prod (but fixes it quickly).', color: 'var(--term-text)' },
+          { text: '', color: '' },
+          { text: 'OPTIONS', color: 'var(--term-yellow)' },
+          { text: '       --coffee n     required for functionality (n >= 1)', color: 'var(--term-text)' },
+          { text: '       --music rock   optimal performance mode', color: 'var(--term-text)' },
+          { text: '       --lift heavy   stress relief subsystem', color: 'var(--term-text)' },
+          { text: '', color: '' },
+          { text: 'BUGS', color: 'var(--term-yellow)' },
+          { text: '       Talks too much about terminal aesthetics.', color: 'var(--term-dim)' },
+        ]);
+      }
+      return err(`No manual entry for ${args}`);
+
+    case 'ping': {
+      const host = args.trim() || 'localhost';
+      return ok([
+        { text: `PING ${host}: 56 data bytes`, color: 'var(--term-text)' },
+        { text: `64 bytes from ${host}: icmp_seq=0 ttl=64 time=0.42 ms`, color: 'var(--term-green)' },
+        { text: `64 bytes from ${host}: icmp_seq=1 ttl=64 time=0.38 ms`, color: 'var(--term-green)' },
+        { text: `64 bytes from ${host}: icmp_seq=2 ttl=64 time=0.41 ms`, color: 'var(--term-green)' },
+        { text: `64 bytes from ${host}: icmp_seq=3 ttl=64 time=0.39 ms`, color: 'var(--term-green)' },
+        { text: '', color: '' },
+        { text: `--- ${host} ping statistics ---`, color: 'var(--term-dim)' },
+        { text: '4 packets transmitted, 4 received, 0% packet loss', color: 'var(--term-green)' },
+      ]);
+    }
+
+    case 'sudo':
+      return err(`rohith is not in the sudoers file. This incident will be reported. 😈`);
+
+    case 'exit':
+      return ok([
+        { text: "You can't leave. The terminal owns you now. 👁", color: 'var(--term-purple)' },
+      ], 'wave');
+
+    case 'matrix':
+      return ok([
+        { text: 'Wake up, Neo...', color: 'var(--term-green)' },
+        { text: '', color: '' },
+        ...MATRIX_FRAMES.map(f => ({ text: f, color: 'var(--term-green)' })),
+        { text: '', color: '' },
+        { text: 'The Matrix has you.', color: 'var(--term-dim)' },
+      ], 'spin');
+
+    case 'wave':
+      return ok([{ text: '👋', color: 'var(--term-yellow)' }], 'wave');
+
+    case 'spin':
+      return ok([{ text: 'Spinning...', color: 'var(--term-cyan)' }], 'spin');
+
+    case 'dance':
+      return ok([
+        { text: '  \\o/   \\o/   \\o/', color: 'var(--term-yellow)' },
+        { text: '   |     |     |', color: 'var(--term-yellow)' },
+        { text: '  / \\   / \\   / \\', color: 'var(--term-yellow)' },
+        { text: '', color: '' },
+        { text: '🎵 dancing...', color: 'var(--term-purple)' },
+      ], 'celebrate');
+
+    case 'clear':
+      return { lines: null, creatureHint: 'spin' }; // null signals "clear all"
+
+    default:
+      return err(`command not found: ${cmd}. Type 'help' for available commands.`);
+  }
+}
+
+export const TAB_COMPLETIONS = [
+  'help', 'about', 'whoami', 'skills', 'projects', 'ls', 'cat ', 'git log',
+  'git status', 'git log --oneline', 'history', 'date', 'uname -a', 'echo ',
+  'pwd', 'man rohith', 'ping ', 'wave', 'spin', 'dance', 'matrix', 'clear', 'exit',
+  'cat about.txt', 'cat readme.txt', 'cat stats.json', 'cat music.txt', 'cat movies.txt',
+  'ls skills/', 'ls projects/', 'sudo ',
+];

--- a/src/hooks/useTerminal.js
+++ b/src/hooks/useTerminal.js
@@ -1,0 +1,121 @@
+import { useState, useCallback, useRef } from 'react';
+import { runCommand, TAB_COMPLETIONS } from '../constants/terminalCommands';
+
+let lineIdCounter = 0;
+function makeId() { return `l${++lineIdCounter}`; }
+
+export default function useTerminal() {
+  const [lines, setLines] = useState([]);
+  const [inputValue, setInputValue] = useState('');
+  const [cmdHistory, setCmdHistory] = useState([]);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  const [creatureState, setCreatureState] = useState('boot');
+  const [isBooting, setIsBooting] = useState(true);
+  const creatureTimerRef = useRef(null);
+
+  const triggerCreature = useCallback((state) => {
+    if (state === 'idle') return;
+    clearTimeout(creatureTimerRef.current);
+    setCreatureState(state);
+    const duration = state === 'spin' ? 1500 : state === 'celebrate' ? 1200 : 1000;
+    creatureTimerRef.current = setTimeout(() => setCreatureState('idle'), duration);
+  }, []);
+
+  const appendLines = useCallback((newLines) => {
+    setLines(prev => [
+      ...prev,
+      ...newLines.map(l => ({ ...l, id: makeId() })),
+    ]);
+  }, []);
+
+  const executeCommand = useCallback((raw) => {
+    const trimmed = raw.trim();
+    if (!trimmed) return;
+
+    // Echo the command line
+    setLines(prev => [
+      ...prev,
+      { id: makeId(), text: trimmed, color: 'var(--term-cyan)', isCommand: true },
+    ]);
+
+    setCmdHistory(prev => [trimmed, ...prev]);
+    setHistoryIndex(-1);
+
+    // Brief thinking state
+    setCreatureState('thinking');
+
+    setTimeout(() => {
+      const { lines: outLines, creatureHint } = runCommand(trimmed, {
+        history: cmdHistory,
+      });
+
+      if (outLines === null) {
+        // clear command
+        setLines([]);
+      } else if (outLines && outLines.length > 0) {
+        appendLines(outLines);
+      }
+
+      triggerCreature(creatureHint || 'celebrate');
+    }, 180);
+  }, [cmdHistory, appendLines, triggerCreature]);
+
+  const handleKeyDown = useCallback((e) => {
+    if (e.key === 'Enter') {
+      executeCommand(inputValue);
+      setInputValue('');
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setCmdHistory(hist => {
+        const next = Math.min(historyIndex + 1, hist.length - 1);
+        setHistoryIndex(next);
+        if (hist[next] !== undefined) setInputValue(hist[next]);
+        return hist;
+      });
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      const next = historyIndex - 1;
+      setHistoryIndex(next);
+      setInputValue(next < 0 ? '' : cmdHistory[next] || '');
+    } else if (e.key === 'Tab') {
+      e.preventDefault();
+      const matches = TAB_COMPLETIONS.filter(c =>
+        c.startsWith(inputValue) && c !== inputValue
+      );
+      if (matches.length === 1) {
+        setInputValue(matches[0]);
+      } else if (matches.length > 1) {
+        appendLines([{ text: matches.join('   '), color: 'var(--term-dim)' }]);
+      }
+    } else if (e.key === 'c' && e.ctrlKey) {
+      e.preventDefault();
+      if (inputValue) {
+        setLines(prev => [
+          ...prev,
+          { id: makeId(), text: inputValue + '^C', color: 'var(--term-dim)', isCommand: true },
+        ]);
+      }
+      setInputValue('');
+      setHistoryIndex(-1);
+    } else if (e.key === 'l' && e.ctrlKey) {
+      e.preventDefault();
+      setLines([]);
+    }
+  }, [inputValue, historyIndex, cmdHistory, executeCommand, appendLines]);
+
+  const handleBootComplete = useCallback(() => {
+    setIsBooting(false);
+    setCreatureState('idle');
+    appendLines([{ text: '', color: '' }]);
+  }, [appendLines]);
+
+  return {
+    lines,
+    inputValue,
+    setInputValue,
+    creatureState,
+    isBooting,
+    handleKeyDown,
+    handleBootComplete,
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -431,3 +431,306 @@ body {
     grid-template-columns: 1fr;
   }
 }
+
+/* ════════════════════════════════════════════════════
+   INTERACTIVE TERMINAL PAGE
+   ════════════════════════════════════════════════════ */
+
+/* Title bar (decorative macOS-style dots) */
+.terminal-titlebar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--term-surface);
+  border: 1px solid var(--term-border);
+  border-bottom: none;
+  border-radius: 4px 4px 0 0;
+  padding: 8px 14px;
+  user-select: none;
+}
+
+.terminal-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.terminal-dot--red    { background: #f87171; }
+.terminal-dot--yellow { background: #fbbf24; }
+.terminal-dot--green  { background: #4ade80; }
+
+.terminal-titlebar-label {
+  margin-left: 8px;
+  font-size: 11px;
+  color: var(--term-dim);
+  flex: 1;
+  text-align: center;
+  padding-right: 58px; /* offset the dots */
+}
+
+/* Main terminal container */
+.terminal-body {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: calc(100vh - 200px);
+  background: var(--term-bg);
+  border: 1px solid var(--term-border);
+  border-top: none;
+  border-radius: 0 0 4px 4px;
+  position: relative;
+  cursor: text;
+  overflow: hidden;
+}
+
+/* Scrollable output area */
+.terminal-scroll-area {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 20px 80px 20px;
+  position: relative;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+/* Individual output lines */
+.terminal-output {
+  font-size: inherit;
+}
+
+/* Sticky input line at bottom */
+.terminal-input-wrapper {
+  position: sticky;
+  bottom: 0;
+  background: var(--term-surface);
+  border-top: 1px solid var(--term-border);
+  padding: 10px 20px;
+  z-index: 5;
+}
+
+.terminal-input-line {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  font-size: 13px;
+  cursor: text;
+}
+
+/* ════════════════════════════════════════════════════
+   CLAUDE CREATURE MASCOT
+   ════════════════════════════════════════════════════ */
+
+/* Creature container — lives in bottom-right of scroll area */
+.creature-wrapper {
+  position: absolute;
+  bottom: 20px;
+  right: 20px;
+  width: 72px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  z-index: 10;
+  cursor: default;
+  user-select: none;
+  will-change: transform;
+}
+
+/* ── Body ────────────────────────────────────────── */
+.creature-body {
+  width: 68px;
+  height: 72px;
+  background: #DA7756;
+  border-radius: 60% 40% 55% 45% / 50% 45% 55% 50%;
+  position: relative;
+  animation: creature-breathe 3s ease-in-out infinite,
+             creature-float   4s ease-in-out infinite;
+  will-change: transform;
+}
+
+.creature-body--happy {
+  border-radius: 50% 50% 60% 40% / 45% 45% 55% 55% !important;
+}
+
+.creature-body--sad {
+  border-radius: 40% 60% 45% 55% / 55% 55% 45% 45% !important;
+}
+
+.creature-body--thinking {
+  animation: creature-think 1.2s ease-in-out infinite !important;
+}
+
+/* ── Highlight sheen ─────────────────────────────── */
+.creature-highlight {
+  position: absolute;
+  width: 18px;
+  height: 10px;
+  background: rgba(255,255,255,0.22);
+  border-radius: 50%;
+  top: 10px;
+  left: 10px;
+  transform: rotate(-30deg);
+  pointer-events: none;
+}
+
+/* ── Eyes ────────────────────────────────────────── */
+.creature-eyes {
+  display: flex;
+  gap: 10px;
+  position: absolute;
+  top: 22px;
+  left: 50%;
+  transform: translateX(-50%);
+  animation: creature-blink 4s ease-in-out infinite;
+}
+
+.creature-eye {
+  width: 14px;
+  height: 14px;
+  background: #1a1a1a;
+  border-radius: 50%;
+  position: relative;
+  overflow: hidden;
+}
+
+.creature-pupil {
+  width: 7px;
+  height: 7px;
+  background: #0c0c0c;
+  border-radius: 50%;
+  position: absolute;
+  top: 3.5px;
+  left: 3.5px;
+  animation: creature-look 6s ease-in-out infinite;
+}
+
+.creature-eye-right .creature-pupil {
+  animation-delay: 0.4s;
+}
+
+.creature-shine {
+  width: 4px;
+  height: 4px;
+  background: white;
+  border-radius: 50%;
+  position: absolute;
+  top: 2px;
+  left: 2px;
+}
+
+/* ── Mouth ───────────────────────────────────────── */
+.creature-mouth {
+  position: absolute;
+  bottom: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 24px;
+  height: 11px;
+  overflow: hidden;
+}
+
+.creature-mouth::after {
+  content: '';
+  display: block;
+  width: 24px;
+  height: 22px;
+  border: 2.5px solid #1a1a1a;
+  border-radius: 50%;
+  margin-top: -11px;
+}
+
+.creature-mouth--sad {
+  transform: translateX(-50%) scaleY(-1);
+}
+
+/* ── Arms ────────────────────────────────────────── */
+.creature-arm-left,
+.creature-arm-right {
+  position: absolute;
+  width: 11px;
+  height: 22px;
+  background: #C96644;
+  border-radius: 5px;
+  top: 36px;
+}
+
+.creature-arm-left  { left: -6px;  transform-origin: bottom center; }
+.creature-arm-right { right: -6px; transform-origin: bottom center; }
+
+/* ── Feet ────────────────────────────────────────── */
+.creature-feet {
+  display: flex;
+  gap: 12px;
+  margin-top: -4px;
+}
+
+.creature-foot {
+  width: 22px;
+  height: 11px;
+  background: #C96644;
+  border-radius: 50%;
+}
+
+/* ── Thinking bubble ─────────────────────────────── */
+.creature-bubble {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  right: 0;
+  background: var(--term-surface);
+  border: 1px solid var(--term-border);
+  border-radius: 4px 4px 0 4px;
+  padding: 3px 8px;
+  font-size: 12px;
+  color: var(--term-dim);
+  white-space: nowrap;
+  animation: fadeIn 0.2s ease;
+}
+
+/* ════════════════════════════════════════════════════
+   CREATURE KEYFRAME ANIMATIONS
+   ════════════════════════════════════════════════════ */
+
+@keyframes creature-breathe {
+  0%, 100% { transform: scaleY(1)    scaleX(1); }
+  50%       { transform: scaleY(1.04) scaleX(0.97); }
+}
+
+@keyframes creature-float {
+  0%, 100% { transform: translateY(0); }
+  50%       { transform: translateY(-5px); }
+}
+
+@keyframes creature-blink {
+  0%, 88%, 100% { transform: scaleY(1); }
+  92%            { transform: scaleY(0.06); }
+}
+
+@keyframes creature-look {
+  0%,  20%       { transform: translate(0, 0); }
+  25%, 45%       { transform: translate(-2px, 1px); }
+  50%, 70%       { transform: translate(2px, -1px); }
+  75%, 95%       { transform: translate(0, 1px); }
+  100%            { transform: translate(0, 0); }
+}
+
+@keyframes creature-think {
+  0%, 100% { transform: rotate(0deg)   translateY(0); }
+  25%       { transform: rotate(-4deg) translateY(-3px); }
+  75%       { transform: rotate(4deg)  translateY(-3px); }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Responsive (mobile) ────────────────────────── */
+@media (max-width: 640px) {
+  .creature-wrapper {
+    transform: scale(0.75);
+    transform-origin: bottom right;
+  }
+
+  .terminal-scroll-area {
+    padding: 12px 14px 80px 14px;
+  }
+}


### PR DESCRIPTION
Adds a new /terminal route with a full Claude Code-style terminal experience:
- Boot animation types out ASCII banner on load
- 25+ interactive commands: help, about, skills, projects, git log, cat, ls, man rohith, matrix easter egg, and more
- Command history navigation (ArrowUp/Down), Tab completion, Ctrl+C/L
- Animated Claude-like blob creature (orange #DA7756) in the bottom-right corner
  - Idle: breathing, floating, blinking, eye-tracking CSS animations
  - Reacts to commands: celebrate bounce (success), shake (error), spin, arm wave
  - GSAP-driven one-shot animations; CSS keyframes for looping idle states
  - Thinking bubble while processing each command
- Terminal nav link added to TopNav with ~/terminal cwd breadcrumb

https://claude.ai/code/session_01Nx5xc9QmCE5rHKVDsxgB7i