### PR TITLE
feat: proper TUI portfolio with all sections

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,13 @@
 import React, { Suspense, lazy } from 'react';
 import ErrorBoundary from './components/ui/ErrorBoundary';
 
-const Terminal = lazy(() => import('./components/sections/Terminal'));
+const TUI = lazy(() => import('./components/sections/TUI'));
 
 function App() {
   return (
     <ErrorBoundary>
       <Suspense fallback={null}>
-        <Terminal />
+        <TUI />
       </Suspense>
     </ErrorBoundary>
   );

--- a/src/components/sections/TUI.js
+++ b/src/components/sections/TUI.js
@@ -1,0 +1,303 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import CreatureMascot from '../terminal/CreatureMascot';
+
+// ── Data ─────────────────────────────────────────────────
+const SOCIALS = [
+  { label: 'github',   href: 'https://github.com/rohithIlluri' },
+  { label: 'twitter',  href: 'https://twitter.com/rohithilluri' },
+  { label: 'linkedin', href: 'https://linkedin.com/in/rohithilluri' },
+  { label: 'discord',  href: '#' },
+  { label: 'email',    href: 'mailto:rohithilluri@gmail.com' },
+];
+
+const SKILLS = [
+  ['JavaScript', '#fbbf24'], ['TypeScript', '#60a5fa'], ['React',      '#22d3ee'],
+  ['Node.js',    '#4ade80'], ['Python',     '#60a5fa'], ['Java',       '#fb923c'],
+  ['HTML',       '#fb923c'], ['CSS',        '#c084fc'], ['Tailwind',   '#22d3ee'],
+  ['Git',        '#f87171'], ['Docker',     '#60a5fa'], ['AWS',        '#fbbf24'],
+  ['MongoDB',    '#4ade80'], ['PostgreSQL', '#60a5fa'], ['Express.js', '#4ade80'],
+  ['GraphQL',    '#f472b6'],
+];
+
+const PROJECTS = [
+  {
+    name: 'Crave',
+    desc: 'Food marketplace',
+    tech: 'React · Node.js · PostgreSQL',
+    github: 'https://github.com/rohithIlluri/Crave',
+    live: null,
+  },
+  {
+    name: 'CryptoApp',
+    desc: 'Live market dashboard',
+    tech: 'React · WebSocket API',
+    github: 'https://github.com/rohithIlluri/cryptoapp',
+    live: null,
+  },
+  {
+    name: 'Toronto Project',
+    desc: 'Community platform',
+    tech: 'Full-stack',
+    github: 'https://github.com/rohithIlluri',
+    live: null,
+  },
+  {
+    name: 'Nnets',
+    desc: 'Neural network experiments',
+    tech: 'Python',
+    github: 'https://github.com/rohithIlluri/Nnets',
+    live: null,
+  },
+];
+
+const ARTISTS = [
+  { n: '01', name: 'AC/DC',       desc: 'beer in one hand, blood in the other',  url: 'https://open.spotify.com/artist/711MCceyCBcFnzjGY4Q7Un', img: '/artists/ac-dc.jpg' },
+  { n: '02', name: 'The Beatles', desc: 'the best band ever',                    url: 'https://open.spotify.com/artist/3WrFJ7ztbogyGnTHbHJFl2', img: '/artists/the-beatles.jpg' },
+  { n: '03', name: 'A.R. Rahman', desc: 'musical maestro',                       url: 'https://open.spotify.com/artist/1mYsTxnqsietFxj1OgoGbG', img: '/artists/ar-rahman.jpg' },
+  { n: '04', name: 'Linkin Park', desc: 'rip chester bennington',                url: 'https://open.spotify.com/artist/6XyY86QOPPrYVGvF9ch6wz', img: '/artists/linkin-park.jpg' },
+];
+
+const MOVIES = [
+  { n: '01', name: 'Kill Bill: Vol. 1', year: 2003, desc: 'swords and revenge',         url: 'https://www.themoviedb.org/movie/24' },
+  { n: '02', name: 'The Dark Knight',   year: 2008, desc: 'epic superhero masterpiece', url: 'https://www.themoviedb.org/movie/155' },
+  { n: '03', name: 'Interstellar',      year: 2014, desc: 'space exploration epic',     url: 'https://www.themoviedb.org/movie/157336' },
+  { n: '04', name: 'Pulp Fiction',      year: 1994, desc: 'tarantino classic',          url: 'https://www.themoviedb.org/movie/680' },
+];
+
+// ── Sections ─────────────────────────────────────────────
+
+function AboutSection() {
+  return (
+    <div className="tui-panel">
+      <div className="tui-panel-title">whoami</div>
+
+      <p className="tui-body-line" style={{ marginBottom: '1.2rem' }}>
+        self-taught developer.<br />
+        passionate about physics, space, and building things.<br />
+        currently obsessed with performance and clean UIs.
+      </p>
+
+      <p className="tui-body-line tui-dim" style={{ marginBottom: '1.2rem' }}>
+        when not at the keyboard:<br />
+        &nbsp;&nbsp;→ deadlifting heavy things<br />
+        &nbsp;&nbsp;→ ac/dc at unreasonable volumes<br />
+        &nbsp;&nbsp;→ watching kill bill for the 12th time
+      </p>
+
+      <div className="tui-kv-block">
+        {SOCIALS.map(s => (
+          <a key={s.label} href={s.href} target="_blank" rel="noreferrer" className="tui-kv-row tui-link">
+            <span className="tui-kv-key">{s.label}</span>
+            <span className="tui-kv-val tui-dim">{s.href.replace(/^https?:\/\//, '')}</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SkillsSection() {
+  return (
+    <div className="tui-panel">
+      <div className="tui-panel-title">skills</div>
+      <div className="tui-skills-grid">
+        {SKILLS.map(([name, color]) => (
+          <span key={name} className="tui-skill-tag" style={{ '--tag-color': color }}>
+            {name}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ProjectsSection() {
+  return (
+    <div className="tui-panel">
+      <div className="tui-panel-title">projects</div>
+      <div className="tui-project-list">
+        {PROJECTS.map(p => (
+          <div key={p.name} className="tui-project-row">
+            <div className="tui-project-header">
+              <span className="tui-project-name">{p.name}</span>
+              <span className="tui-dim tui-project-desc">{p.desc}</span>
+            </div>
+            <div className="tui-project-tech tui-dim">{p.tech}</div>
+            <div className="tui-project-links">
+              {p.github && (
+                <a href={p.github} target="_blank" rel="noreferrer" className="tui-btn">
+                  github ↗
+                </a>
+              )}
+              {p.live && (
+                <a href={p.live} target="_blank" rel="noreferrer" className="tui-btn">
+                  live ↗
+                </a>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MusicSection() {
+  return (
+    <div className="tui-panel">
+      <div className="tui-panel-title">music</div>
+      <div className="tui-list">
+        {ARTISTS.map(a => (
+          <a key={a.name} href={a.url} target="_blank" rel="noreferrer" className="tui-list-row tui-link">
+            <img src={a.img} alt={a.name} className="tui-thumb" />
+            <span className="tui-list-num tui-dim">{a.n}</span>
+            <span className="tui-list-name">{a.name}</span>
+            <span className="tui-list-desc tui-dim">{a.desc}</span>
+            <span className="tui-list-arrow tui-dim">↗</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MoviesSection() {
+  return (
+    <div className="tui-panel">
+      <div className="tui-panel-title">movies</div>
+      <div className="tui-list">
+        {MOVIES.map(m => (
+          <a key={m.name} href={m.url} target="_blank" rel="noreferrer" className="tui-list-row tui-link">
+            <span className="tui-list-num tui-dim">{m.n}</span>
+            <span className="tui-list-name">{m.name}</span>
+            <span className="tui-list-year tui-dim">({m.year})</span>
+            <span className="tui-list-desc tui-dim">{m.desc}</span>
+            <span className="tui-list-arrow tui-dim">↗</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StatsSection() {
+  const stats = [
+    ['deadlift pr',    '340 lbs'],
+    ['bench press',    '180 lbs'],
+    ['run',            '11.32 miles'],
+    ['typing (30s)',   '95 wpm'],
+    ['typing (15s)',   '103 wpm'],
+    ['coffee / day',   '3'],
+  ];
+  return (
+    <div className="tui-panel">
+      <div className="tui-panel-title">stats</div>
+      <div className="tui-kv-block">
+        {stats.map(([k, v]) => (
+          <div key={k} className="tui-kv-row">
+            <span className="tui-kv-key tui-dim">{k}</span>
+            <span className="tui-kv-val">{v}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Section registry ──────────────────────────────────────
+const SECTIONS = [
+  { id: 'about',    label: 'about',    Component: AboutSection    },
+  { id: 'skills',   label: 'skills',   Component: SkillsSection   },
+  { id: 'projects', label: 'projects', Component: ProjectsSection },
+  { id: 'music',    label: 'music',    Component: MusicSection    },
+  { id: 'movies',   label: 'movies',   Component: MoviesSection   },
+  { id: 'stats',    label: 'stats',    Component: StatsSection    },
+];
+
+// ── Main TUI ──────────────────────────────────────────────
+export default function TUI() {
+  const [active, setActive]     = useState(0);
+  const [creature, setCreature] = useState('idle');
+  const creatureTimer = useRef(null);
+
+  const goTo = useCallback((idx) => {
+    setActive(idx);
+    clearTimeout(creatureTimer.current);
+    setCreature('celebrate');
+    creatureTimer.current = setTimeout(() => setCreature('idle'), 1200);
+  }, []);
+
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+
+      if (e.key === 'ArrowRight' || e.key === 'l') {
+        setActive(a => {
+          const n = (a + 1) % SECTIONS.length;
+          clearTimeout(creatureTimer.current);
+          setCreature('celebrate');
+          creatureTimer.current = setTimeout(() => setCreature('idle'), 1200);
+          return n;
+        });
+      } else if (e.key === 'ArrowLeft' || e.key === 'h') {
+        setActive(a => {
+          const n = (a - 1 + SECTIONS.length) % SECTIONS.length;
+          clearTimeout(creatureTimer.current);
+          setCreature('celebrate');
+          creatureTimer.current = setTimeout(() => setCreature('idle'), 1200);
+          return n;
+        });
+      } else if (e.key >= '1' && e.key <= '6') {
+        goTo(parseInt(e.key, 10) - 1);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [goTo]);
+
+  const { Component } = SECTIONS[active];
+
+  return (
+    <div className="tui-root">
+
+      {/* Header */}
+      <header className="tui-header">
+        <span className="tui-header-name">rohith illuri</span>
+        <span className="tui-header-sub">self-taught developer</span>
+      </header>
+
+      {/* Tab bar */}
+      <nav className="tui-tabs" role="tablist">
+        {SECTIONS.map((s, i) => (
+          <button
+            key={s.id}
+            role="tab"
+            aria-selected={i === active}
+            onClick={() => goTo(i)}
+            className={`tui-tab${i === active ? ' tui-tab--active' : ''}`}
+          >
+            <span className="tui-tab-num">{i + 1}</span>
+            {s.label}
+          </button>
+        ))}
+      </nav>
+
+      {/* Content */}
+      <main className="tui-content" role="tabpanel">
+        <div key={active} className="tui-fade">
+          <Component />
+        </div>
+
+        <CreatureMascot animationState={creature} />
+      </main>
+
+      {/* Status bar */}
+      <footer className="tui-status">
+        <span>← → navigate</span>
+        <span className="tui-dim">1 – 6 jump to section</span>
+        <span className="tui-status-right">rohith@portfolio</span>
+      </footer>
+
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -6,18 +6,20 @@
 :root {
   --bg:      #0c0c0c;
   --text:    #c8c8c8;
-  --dim:     #444;
+  --dim:     #505050;
   --green:   #4ade80;
   --border:  #1e1e1e;
-  --surface: #111;
+  --surface: #111111;
+  --radius:  2px;
 }
 
-/* ── Base ────────────────────────────────────────────── */
-* { box-sizing: border-box; }
+/* ── Reset ───────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 html {
   font-size: 14px;
   background: var(--bg);
+  height: 100%;
 }
 
 body {
@@ -26,127 +28,312 @@ body {
   color: var(--text);
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
-  margin: 0;
-  padding: 0;
+  height: 100%;
 }
 
-::selection {
-  background: rgba(74, 222, 128, 0.15);
-  color: var(--text);
-}
+#root { height: 100%; }
 
-::-webkit-scrollbar { width: 4px; }
-::-webkit-scrollbar-track { background: var(--bg); }
+a { color: inherit; text-decoration: none; }
+
+::selection { background: rgba(74,222,128,0.15); color: var(--text); }
+
+::-webkit-scrollbar { width: 4px; height: 4px; }
+::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: #222; border-radius: 2px; }
 
-/* ── Terminal root (full page) ───────────────────────── */
-.t-root {
-  min-height: 100vh;
+/* ══════════════════════════════════════════════════════
+   TUI SHELL
+   ══════════════════════════════════════════════════════ */
+
+.tui-root {
   display: flex;
   flex-direction: column;
-  cursor: text;
-  padding: 0 20px;
-  max-width: 820px;
+  height: 100vh;
+  max-width: 860px;
   margin: 0 auto;
+  border-left: 1px solid var(--border);
+  border-right: 1px solid var(--border);
 }
 
-/* ── Scrollable output area ──────────────────────────── */
-.t-scroll {
-  flex: 1;
-  overflow-y: auto;
-  padding: 28px 0 120px;
-  position: relative;
-}
-
-/* ── Output lines ────────────────────────────────────── */
-.t-output {
-  font-size: 13px;
-}
-
-.t-line {
-  line-height: 1.65;
-  min-height: 1.4em;
-  color: var(--text);
-  white-space: pre;
-  font-family: inherit;
-}
-
-.t-line--green { color: var(--green); }
-.t-line--dim   { color: var(--dim); }
-.t-line--cmd   { color: var(--text); }
-
-/* ── Prompt ──────────────────────────────────────────── */
-.t-prompt {
-  color: var(--green);
-  user-select: none;
+/* Header */
+.tui-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 20px;
+  border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
 
-/* ── Input line (sticky bottom) ─────────────────────── */
-.t-input-wrapper {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  background: var(--bg);
-  border-top: 1px solid var(--border);
-  padding: 12px 20px;
-  z-index: 10;
-}
-
-/* Center align the input with the content */
-.t-input-wrapper > * {
-  max-width: 820px;
-  margin: 0 auto;
-}
-
-.t-input-line {
-  display: flex;
-  align-items: center;
+.tui-header-name {
+  color: var(--green);
   font-size: 13px;
-  cursor: text;
+  font-weight: 600;
+  letter-spacing: 0.03em;
 }
 
-.t-input {
-  flex: 1;
+.tui-header-sub {
+  font-size: 11px;
+  color: var(--dim);
+}
+
+/* Tab bar */
+.tui-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  flex-shrink: 0;
+  scrollbar-width: none;
+}
+.tui-tabs::-webkit-scrollbar { display: none; }
+
+.tui-tab {
   background: transparent;
   border: none;
-  outline: none;
-  color: var(--text);
+  border-bottom: 2px solid transparent;
+  padding: 8px 18px;
+  color: var(--dim);
   font-family: inherit;
-  font-size: inherit;
-  caret-color: var(--green);
-  min-width: 0;
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 100ms, border-color 100ms;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: -1px;
 }
 
-/* ── Boot text ───────────────────────────────────────── */
-.boot-text {
+.tui-tab:hover { color: var(--text); }
+
+.tui-tab--active {
   color: var(--green);
-  font-family: inherit;
-  font-size: 13px;
-  margin: 0 0 4px 0;
-  white-space: pre;
-  line-height: 1.5;
+  border-bottom-color: var(--green);
+}
+
+.tui-tab-num {
+  font-size: 10px;
+  opacity: 0.5;
+}
+
+/* Content area */
+.tui-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 28px 24px 100px;
+  position: relative;
+}
+
+/* Fade animation on section switch */
+.tui-fade {
+  animation: tuiFade 0.15s ease;
+}
+
+@keyframes tuiFade {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Status bar */
+.tui-status {
+  border-top: 1px solid var(--border);
+  padding: 6px 20px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  font-size: 11px;
+  color: var(--dim);
+  flex-shrink: 0;
+}
+
+.tui-status-right {
+  margin-left: auto;
+  color: var(--green);
 }
 
 /* ══════════════════════════════════════════════════════
-   SONG — THE CREATURE
+   SECTION PANEL
+   ══════════════════════════════════════════════════════ */
+
+.tui-panel { max-width: 640px; }
+
+.tui-panel-title {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--green);
+  margin-bottom: 16px;
+}
+
+.tui-body-line {
+  font-size: 13px;
+  line-height: 1.8;
+  color: var(--text);
+}
+
+.tui-dim { color: var(--dim); }
+
+/* Key-value block */
+.tui-kv-block { display: flex; flex-direction: column; gap: 4px; }
+
+.tui-kv-row {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 4px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+
+.tui-kv-row:last-child { border-bottom: none; }
+
+.tui-kv-key {
+  min-width: 120px;
+  flex-shrink: 0;
+}
+
+.tui-kv-val { flex: 1; }
+
+.tui-link {
+  display: flex;
+  transition: color 100ms;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.tui-link:hover { color: var(--green); }
+.tui-link:hover .tui-dim { color: var(--green); opacity: 0.6; }
+
+/* Skills grid */
+.tui-skills-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tui-skill-tag {
+  padding: 3px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 12px;
+  color: var(--tag-color, var(--text));
+  background: transparent;
+  transition: background 100ms;
+}
+
+.tui-skill-tag:hover {
+  background: rgba(255,255,255,0.04);
+}
+
+/* Project list */
+.tui-project-list { display: flex; flex-direction: column; gap: 0; }
+
+.tui-project-row {
+  padding: 14px 0;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.tui-project-row:last-child { border-bottom: none; }
+
+.tui-project-header {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.tui-project-name {
+  font-size: 13px;
+  color: var(--green);
+  font-weight: 600;
+}
+
+.tui-project-desc { font-size: 12px; }
+
+.tui-project-tech { font-size: 11px; }
+
+.tui-project-links {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.tui-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 11px;
+  color: var(--dim);
+  font-family: inherit;
+  cursor: pointer;
+  text-decoration: none;
+  transition: border-color 100ms, color 100ms;
+}
+
+.tui-btn:hover {
+  border-color: var(--green);
+  color: var(--green);
+}
+
+/* Music / Movie list */
+.tui-list { display: flex; flex-direction: column; gap: 0; }
+
+.tui-list-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  transition: color 100ms;
+}
+
+.tui-list-row:last-child { border-bottom: none; }
+.tui-list-row:hover { color: var(--green); }
+.tui-list-row:hover .tui-dim { color: var(--green); opacity: 0.55; }
+
+.tui-thumb {
+  width: 36px;
+  height: 36px;
+  object-fit: cover;
+  border-radius: var(--radius);
+  flex-shrink: 0;
+  opacity: 0.85;
+  filter: grayscale(20%);
+}
+
+.tui-list-num   { width: 24px; flex-shrink: 0; font-size: 11px; }
+.tui-list-name  { flex: 1; min-width: 0; }
+.tui-list-year  { font-size: 11px; flex-shrink: 0; }
+.tui-list-desc  { font-size: 11px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tui-list-arrow { flex-shrink: 0; font-size: 11px; }
+
+/* ══════════════════════════════════════════════════════
+   CREATURE — Song
    ══════════════════════════════════════════════════════ */
 
 .creature-wrapper {
-  position: absolute;
-  bottom: 80px;
-  right: 0;
+  position: fixed;
+  bottom: 38px;   /* sit above status bar */
+  right: calc((100vw - 860px) / 2 + 12px);
   width: 72px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  z-index: 10;
+  z-index: 20;
   user-select: none;
   will-change: transform;
+  pointer-events: none;
 }
 
-/* Body */
+@media (max-width: 860px) {
+  .creature-wrapper { right: 12px; }
+}
+
 .creature-body {
   width: 68px;
   height: 72px;
@@ -162,104 +349,70 @@ body {
 .creature-body--sad     { border-radius: 40% 60% 45% 55% / 55% 55% 45% 45% !important; }
 .creature-body--thinking { animation: c-think 1.2s ease-in-out infinite !important; }
 
-/* Highlight */
 .creature-highlight {
-  position: absolute;
-  width: 18px; height: 10px;
-  background: rgba(255,255,255,0.22);
-  border-radius: 50%;
-  top: 10px; left: 10px;
-  transform: rotate(-30deg);
+  position: absolute; width: 18px; height: 10px;
+  background: rgba(255,255,255,0.22); border-radius: 50%;
+  top: 10px; left: 10px; transform: rotate(-30deg);
   pointer-events: none;
 }
 
-/* Eyes */
 .creature-eyes {
-  display: flex;
-  gap: 10px;
-  position: absolute;
-  top: 22px;
-  left: 50%;
+  display: flex; gap: 10px;
+  position: absolute; top: 22px; left: 50%;
   transform: translateX(-50%);
   animation: c-blink 4s ease-in-out infinite;
 }
 
 .creature-eye {
   width: 14px; height: 14px;
-  background: #111;
-  border-radius: 50%;
-  position: relative;
-  overflow: hidden;
+  background: #111; border-radius: 50%;
+  position: relative; overflow: hidden;
 }
 
 .creature-pupil {
   width: 7px; height: 7px;
-  background: #0a0a0a;
-  border-radius: 50%;
-  position: absolute;
-  top: 3.5px; left: 3.5px;
+  background: #0a0a0a; border-radius: 50%;
+  position: absolute; top: 3.5px; left: 3.5px;
   animation: c-look 6s ease-in-out infinite;
 }
 
 .creature-eye-right .creature-pupil { animation-delay: 0.4s; }
 
 .creature-shine {
-  width: 4px; height: 4px;
-  background: white;
-  border-radius: 50%;
-  position: absolute;
-  top: 2px; left: 2px;
+  width: 4px; height: 4px; background: white; border-radius: 50%;
+  position: absolute; top: 2px; left: 2px;
 }
 
-/* Mouth */
 .creature-mouth {
-  position: absolute;
-  bottom: 14px;
-  left: 50%;
+  position: absolute; bottom: 14px; left: 50%;
   transform: translateX(-50%);
-  width: 24px; height: 11px;
-  overflow: hidden;
+  width: 24px; height: 11px; overflow: hidden;
 }
 
 .creature-mouth::after {
-  content: '';
-  display: block;
+  content: ''; display: block;
   width: 24px; height: 22px;
-  border: 2.5px solid #111;
-  border-radius: 50%;
-  margin-top: -11px;
+  border: 2.5px solid #111; border-radius: 50%; margin-top: -11px;
 }
 
 .creature-mouth--sad { transform: translateX(-50%) scaleY(-1); }
 
-/* Arms */
 .creature-arm-left, .creature-arm-right {
-  position: absolute;
-  width: 11px; height: 22px;
-  background: #C96644;
-  border-radius: 5px;
-  top: 36px;
+  position: absolute; width: 11px; height: 22px;
+  background: #C96644; border-radius: 5px; top: 36px;
 }
 
 .creature-arm-left  { left: -6px;  transform-origin: bottom center; }
 .creature-arm-right { right: -6px; transform-origin: bottom center; }
 
-/* Feet */
 .creature-feet { display: flex; gap: 12px; margin-top: -4px; }
 .creature-foot { width: 22px; height: 11px; background: #C96644; border-radius: 50%; }
 
-/* Thinking bubble */
 .creature-bubble {
-  position: absolute;
-  bottom: calc(100% + 4px);
-  right: 0;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 4px 4px 0 4px;
-  padding: 3px 8px;
-  font-size: 11px;
-  color: var(--dim);
-  white-space: nowrap;
+  position: absolute; bottom: calc(100% + 4px); right: 0;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 4px 4px 0 4px; padding: 3px 8px;
+  font-size: 11px; color: var(--dim); white-space: nowrap;
   animation: fadeIn 0.2s ease;
 }
 
@@ -300,13 +453,15 @@ body {
 }
 
 /* ── Mobile ──────────────────────────────────────────── */
-@media (max-width: 640px) {
+@media (max-width: 600px) {
   html { font-size: 12px; }
-
-  .t-root { padding: 0 14px; }
+  .tui-content { padding: 20px 16px 100px; }
+  .tui-tab     { padding: 8px 12px; }
 
   .creature-wrapper {
-    transform: scale(0.7);
+    transform: scale(0.72);
     transform-origin: bottom right;
   }
+
+  .tui-list-desc { display: none; }
 }


### PR DESCRIPTION
Replaces the command-prompt terminal with a proper TUI portfolio.

## Layout
- **Header**: `rohith illuri` · `self-taught developer`
- **Tab bar**: about / skills / projects / music / movies / stats
- **Content**: selected section with fade transition
- **Status bar**: keyboard hints + `rohith@portfolio`
- **Creature**: fixed bottom-right, bounces on every tab switch

## Sections
- **about** — bio, interests, social links
- **skills** — color-coded tags matching original colors
- **projects** — Crave, CryptoApp, Toronto Proj, Nnets with GitHub links
- **music** — artist list with thumbnails + Spotify links
- **movies** — film list with TMDB links
- **stats** — personal records (deadlift, bench, run, typing)

## Navigation
- `← →` to switch tabs
- `1`–`6` to jump directly

https://claude.ai/code/session_01Nx5xc9QmCE5rHKVDsxgB7i